### PR TITLE
Only run goreleaser on push when new tag is added, not on pull request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     # run only against tags
     tags:


### PR DESCRIPTION
There was a miss in the workflow for goreleaser, making it run on each PR. With this change, it will only run on push whenever a new tag is created. 