### PR TITLE
Save and restore DB comments

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/cotramarko/snapvault/internal/utils"
 	"os"
 
 	"github.com/cotramarko/snapvault/internal/commands"
@@ -32,14 +33,15 @@ var listCmd = &cobra.Command{
 
 		t := table.NewWriter()
 		t.SetOutputMirror(os.Stdout)
-		t.AppendHeader(table.Row{"Name", "Created", "Size"})
+		t.AppendHeader(table.Row{"Name", "Created", "Size", "Comment"})
 		t.SetColumnConfigs([]table.ColumnConfig{
 			{Name: "Created", AlignHeader: text.AlignCenter, AlignFooter: text.AlignRight},
-			{Name: "Size", AlignHeader: text.AlignRight, Align: text.AlignRight},
+			{Name: "Size", AlignHeader: text.AlignCenter, Align: text.AlignRight},
+			{Name: "Comment", AlignHeader: text.AlignRight, Align: text.AlignLeft},
 		})
 
 		for _, d := range snapshots {
-			t.AppendRow(table.Row{d.SnapName, d.Created, d.Size})
+			t.AppendRow(table.Row{d.SnapName, d.Created, d.Size, utils.TruncateComment(d.Comment)})
 		}
 		t.AppendSeparator()
 		/*

--- a/db/schema-and-seed.sql
+++ b/db/schema-and-seed.sql
@@ -52,4 +52,5 @@ VALUES
     (1, 199.95),
     (2, 299.95);
 
--- Note: Adjust the INSERT statements as necessary to match your application's needs
+-- Add comment on Database
+COMMENT ON DATABASE acmedb IS 'Dummy comment on acmedb';

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -1,0 +1,18 @@
+package utils
+
+import "unicode/utf8"
+
+const MaxLengthComments = 72
+
+func truncateText(text string, maxLength int) string {
+	if utf8.RuneCountInString(text) <= maxLength {
+		return text
+	}
+
+	truncated := string([]rune(text)[:maxLength-3])
+	return truncated + "..."
+}
+
+func TruncateComment(comment string) string {
+	return truncateText(comment, MaxLengthComments)
+}

--- a/tests/commands_test.go
+++ b/tests/commands_test.go
@@ -41,6 +41,10 @@ func TestCoreCommands(t *testing.T) {
 		t.Error("Expected 1 snapshot, got", len(res))
 	}
 
+	if res[0].Comment == "" {
+		t.Error("Expected DB comment to be present, but it was blank")
+	}
+
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Summary: I've found this tool very useful (thank you for building it!), but one issue I've run into is that when I save a snapshot and then restore it later it will clear the comment which was present on the database when it was snapshotted. We have a workflow in our dev environment which depends on DB comments, which is why I've noticed this behavior.

This updates the `save` and `restore` commands to also save DB comments. When running `save` it will see if a comment exists on the DB being snapshot, and if so set the same comment on the snapshot DB. When running `restore` it will look for a comment on the snapshot DB being restored, and set it on the newly created DB if it exists.

It might make sense to also show saved comments when running `list`, but I didn't do that here.

I debated if this should be enabled via a flag people need to set to opt-in to this behavior, but I didn't see a reason people who are using DB comments wouldn't want this.

I tried using pq query parameters when specifying the comment, but it seemed like that didn't work with pq (maybe because the `COMMENT ON...` is an odd query), so instead I used `pq.QuoteLiteral` to escape the comment.

Test Plan: tested running `save` and `restore` for a DB with a comment. confirmed that the comment was restored correctly, even if it was changed on the DB that was overwritten by the restore in the meantime.

tested running `save` and `restore` for a DB without any comment, and confirmed both ran with no error, and no comment was saved on the DB or the snapshot.